### PR TITLE
Add 1688 order scraping example

### DIFF
--- a/1688_order_export.user.js
+++ b/1688_order_export.user.js
@@ -1,0 +1,47 @@
+// ==UserScript==
+// @name         1688 Order Exporter
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @description  Export order list from 1688 to CSV for importing into Excel
+// @match        https://trade.1688.com/order/*
+// @grant        none
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    function exportOrders() {
+        const rows = document.querySelectorAll('div.order-item');
+        const csvRows = ['商品名称,购买数量,下单日期,是否退货'];
+        rows.forEach(row => {
+            const name = row.querySelector('.order-item-title')?.innerText.trim() || '';
+            const qty = row.querySelector('.order-item-quantity')?.innerText.trim() || '';
+            const date = row.querySelector('.order-item-date')?.innerText.trim() || '';
+            const refund = row.querySelector('.order-item-refund')?.innerText.trim() || '';
+            csvRows.push([name, qty, date, refund].join(','));
+        });
+        const blob = new Blob([csvRows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'orders.csv';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    function addExportButton() {
+        const btn = document.createElement('button');
+        btn.textContent = '导出订单CSV';
+        btn.style.position = 'fixed';
+        btn.style.top = '10px';
+        btn.style.right = '10px';
+        btn.style.zIndex = 9999;
+        btn.addEventListener('click', exportOrders);
+        document.body.appendChild(btn);
+    }
+
+    window.addEventListener('load', addExportButton);
+})();
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Kian
 My personal GitHub homepage
+
+## Example 1688 Orders Scraper
+
+This repository includes a simple script `simple_1688_spider.py` that demonstrates
+how to fetch order data from 1688 after the user manually logs in. It opens an
+Edge browser via Selenium and saves the scraped data to `orders.xlsx`.
+
+### Requirements
+- Python 3.11
+- `selenium`, `pandas`, `openpyxl` packages
+- Microsoft Edge and the corresponding Edge WebDriver installed on your system
+
+### Usage
+1. Install the required Python packages:
+   ```bash
+   pip install selenium pandas openpyxl
+   ```
+2. Make sure Edge WebDriver is available in your `PATH`.
+3. Run the script:
+   ```bash
+   python simple_1688_spider.py
+   ```
+4. When the browser opens, log in to 1688 manually. After login, press `Enter`
+   in the terminal to let the script continue. It will parse the orders page
+   (you may need to adjust the CSS selectors in the script) and save the data
+   to `orders.xlsx`.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ Edge browser via Selenium and saves the scraped data to `orders.xlsx`.
    in the terminal to let the script continue. It will parse the orders page
    (you may need to adjust the CSS selectors in the script) and save the data
    to `orders.xlsx`.
+
+## Tampermonkey Script
+
+If you prefer to scrape orders directly in your browser, this repo also
+includes `1688_order_export.user.js`. Install the [Tampermonkey](https://www.tampermonkey.net/)
+extension in Edge or Chrome, create a new script, and paste the contents of
+`1688_order_export.user.js`.
+
+When you browse the 1688 order list page (e.g. `https://trade.1688.com/order/`),
+a button labeled `导出订单CSV` will appear in the top right corner. Click it to
+export the current page’s orders to a CSV file that can be opened in Excel.
+

--- a/simple_1688_spider.py
+++ b/simple_1688_spider.py
@@ -1,0 +1,39 @@
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+import pandas as pd
+
+
+def main():
+    options = webdriver.EdgeOptions()
+    driver = webdriver.Edge(options=options)
+
+    # 打开 1688 订单页面，会自动跳转登录
+    orders_url = "https://trade.1688.com/order/sell_order_list.htm"
+    driver.get(orders_url)
+
+    input("请在浏览器中完成登录后按回车继续...")
+
+    data = []
+    # 下面的选择器需要根据实际页面结构调整
+    order_rows = driver.find_elements(By.CSS_SELECTOR, "div.order-item")
+    for row in order_rows:
+        name = row.find_element(By.CSS_SELECTOR, ".order-item-title").text
+        qty = row.find_element(By.CSS_SELECTOR, ".order-item-quantity").text
+        date = row.find_element(By.CSS_SELECTOR, ".order-item-date").text
+        refund = row.find_element(By.CSS_SELECTOR, ".order-item-refund").text
+        data.append({
+            "商品名称": name,
+            "购买数量": qty,
+            "下单日期": date,
+            "是否退货": refund,
+        })
+
+    df = pd.DataFrame(data)
+    df.to_excel("orders.xlsx", index=False)
+    print("已保存到 orders.xlsx")
+    driver.quit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a sample Selenium scraper for 1688 orders
- document how to run `simple_1688_spider.py` in README

## Testing
- `python -m py_compile simple_1688_spider.py`
- `pip install selenium pandas openpyxl` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68850e0f5d1083289d4015bb145f84ae